### PR TITLE
Set options to empty object as default

### DIFF
--- a/lib/regiment.js
+++ b/lib/regiment.js
@@ -22,6 +22,8 @@ function makeWorker(workerFunc) {
 const Regiment = function(workerFunc, options) {
   if (cluster.isWorker) return makeWorker(workerFunc);
 
+  options = options || {};
+
   const numCpus = os.cpus().length;
   let running = true;
 


### PR DESCRIPTION
Prevents regiment from crashing if attempted started without an
options argument.
