### PR TITLE
Address node deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for the worker to die by itself and then forcefully kill it.
  on a 2x dyno where we account for startup memory usage of the replacement worker being ~100mb and
  give it a bit of a cushion for memory to balloon during the deadline (grace period).
  - A deadline (grace period) of 30 seconds is optimal for heroku. This is now the default.
- - Requires Node >= 4.0.0
+ - Requires Node >= 6.0.0
 
 #### Thanks
 

--- a/lib/regiment.js
+++ b/lib/regiment.js
@@ -70,8 +70,8 @@ const Regiment = function(workerFunc, options) {
   }
 
   function respawn(worker, code, signal) {
-    if (running && !worker.suicide) {
-      logger.log(`Respawning ${worker.id} after suicide`);
+    if (running && !worker.exitedAfterDisconnect) {
+      logger.log(`Respawning ${worker.id} after it exited`);
       spawn();
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Tyler Brock",
   "license": "MIT",
   "engines": {
-    "node" : ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "bugs": {
     "url": "https://github.com/HustleInc/regiment/issues"


### PR DESCRIPTION
> (node:6316) [DEP0007] DeprecationWarning: worker.suicide is deprecated. Please use worker.exitedAfterDisconnect.

See https://github.com/nodejs/node/issues/3721

Any objections to dropping node 4 and 5 support?